### PR TITLE
feat: Add the rule no object literals.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'pnpm' # See documentation for possible values
+  - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ This rule discourages the use of anonymous functions of any kind. There are mult
 - In some cases, they can increase performance overhead. While this is admittedly a micro-optimization, those of use looking for every millisecond of performance will avoid them.
 - They make it harder to understand code. When you have a function that is more than a few lines, it can be difficult to understand what the function does just by reading the function body. Names help.
 
+### no-object-literals
+
+This rule discourages the use of object literals. They ARE allowed as parameters to constructors because the assumption is that you are going to use it to initialize the class.
+
+There are multiple reasons why you should avoid them:
+
+- They are difficult to debug because you can't see the name in the developer tools. This means when you are tracking down a performance issue in a flame chart, looking at a call stack, or tracking down a memory leak, you'll have to drill into the code to see what the function does.
+- Changing the shape of an object (the order or type of fields) causes the javascript interpreter to create a new internal class for each shape. This has an impact both on memory and performance. By using classes, which use prototypes to fix the order of the fields, we avoid creating a new, internal, class for each shape. For toy applications, this is probably not a problem. For large applications this is a concern worth worrying about.
+- They make it harder to understand code. When you have a function that is more than a few lines, it can be difficult to understand what the function does just by reading the function body. Names help.
+
 ### one-exported-item-per-file
 
 If you've ever worked on a very large codebase, you've already seen the problem where a single file has a bunch of exports in it. And then, when you are trying to re-organize the code into multiple libraries, you realize the problems multiple exports in the same file can cause you. Do yourself a favor and get in the habit of only exporting one item per file. Your future self will thank you.

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -53,6 +53,16 @@ This rule discourages the use of anonymous functions of any kind. There are mult
 - In some cases, they can increase performance overhead. While this is admittedly a micro-optimization, those of use looking for every millisecond of performance will avoid them.
 - They make it harder to understand code. When you have a function that is more than a few lines, it can be difficult to understand what the function does just by reading the function body. Names help.
 
+### no-object-literals
+
+This rule discourages the use of object literals. They ARE allowed as parameters to constructors because the assumption is that you are going to use it to initialize the class.
+
+There are multiple reasons why you should avoid them:
+
+- They are difficult to debug because you can't see the name in the developer tools. This means when you are tracking down a performance issue in a flame chart, looking at a call stack, or tracking down a memory leak, you'll have to drill into the code to see what the function does.
+- Changing the shape of an object (the order or type of fields) causes the javascript interpreter to create a new internal class for each shape. This has an impact both on memory and performance. By using classes, which use prototypes to fix the order of the fields, we avoid creating a new, internal, class for each shape. For toy applications, this is probably not a problem. For large applications this is a concern worth worrying about.
+- They make it harder to understand code. When you have a function that is more than a few lines, it can be difficult to understand what the function does just by reading the function body. Names help.
+
 ### one-exported-item-per-file
 
 If you've ever worked on a very large codebase, you've already seen the problem where a single file has a bunch of exports in it. And then, when you are trying to re-organize the code into multiple libraries, you realize the problems multiple exports in the same file can cause you. Do yourself a favor and get in the habit of only exporting one item per file. Your future self will thank you.

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,8 +1,8 @@
 import type { Linter } from '@typescript-eslint/utils/ts-eslint';
 
 import noAnonymousFunctions from './lib/no-anonymous-functions/no-anonymous-functions';
-import oneExportedItemPerFile from './lib/one-exported-item-per-file/one-exported-item-per-file';
 import noObjectLiterals from './lib/no-object-literals/no-object-literals';
+import oneExportedItemPerFile from './lib/one-exported-item-per-file/one-exported-item-per-file';
 
 // eslint-disable-next-line typescriptEslintPlugin/no-require-imports, typescriptEslintPlugin/no-var-requires -- needed to get information from package.json
 const { name, version } = require('../package.json') as { name: string; version: string };

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -2,6 +2,7 @@ import type { Linter } from '@typescript-eslint/utils/ts-eslint';
 
 import noAnonymousFunctions from './lib/no-anonymous-functions/no-anonymous-functions';
 import oneExportedItemPerFile from './lib/one-exported-item-per-file/one-exported-item-per-file';
+import noObjectLiterals from './lib/no-object-literals/no-object-literals';
 
 // eslint-disable-next-line typescriptEslintPlugin/no-require-imports, typescriptEslintPlugin/no-var-requires -- needed to get information from package.json
 const { name, version } = require('../package.json') as { name: string; version: string };
@@ -14,6 +15,7 @@ const meta = {
 const rules = {
 	'one-exported-item-per-file': oneExportedItemPerFile,
 	'no-anonymous-functions': noAnonymousFunctions,
+	'no-object-literals': noObjectLiterals,
 } satisfies Linter.PluginRules;
 
 module.exports = { meta, rules } satisfies Linter.Plugin;

--- a/packages/eslint-plugin/src/lib/no-object-literals/message-id.const.ts
+++ b/packages/eslint-plugin/src/lib/no-object-literals/message-id.const.ts
@@ -1,0 +1,1 @@
+export const messageId = 'noObjectLiterals';

--- a/packages/eslint-plugin/src/lib/no-object-literals/no-object-literals.const.ts
+++ b/packages/eslint-plugin/src/lib/no-object-literals/no-object-literals.const.ts
@@ -1,0 +1,1 @@
+export const noObjectLiterals = 'no-object-literals';

--- a/packages/eslint-plugin/src/lib/no-object-literals/no-object-literals.spec.ts
+++ b/packages/eslint-plugin/src/lib/no-object-literals/no-object-literals.spec.ts
@@ -1,0 +1,67 @@
+import { convertAnnotatedSourceToFailureCase } from '@angular-eslint/test-utils';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { messageId } from './message-id.const';
+import rule from './no-object-literals';
+import { noObjectLiterals } from './no-object-literals.const';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run(noObjectLiterals, rule, {
+  valid: [
+    // Allow object literals in constructor calls
+    `new MyClass({ prop: 'value' })`,
+
+    // Allow class usage
+    `class MyClass {
+      method() {}
+    }`,
+
+    // Allow object destructuring
+    `const { prop } = someObject`,
+
+    // Allow object property access
+    `const value = object.property`,
+
+    // Allow empty object in constructor
+    `new MyClass({})`,
+  ],
+  invalid: [
+    convertAnnotatedSourceToFailureCase({
+      messageId,
+      description: 'Simple object literal',
+      annotatedSource: `
+const config = { prop: 'value' };
+               ~~~~~~~~~~~~~~~~~
+`,
+    }),
+
+    convertAnnotatedSourceToFailureCase({
+      messageId,
+      description: 'Object literal in function argument',
+      annotatedSource: `
+function process(data) {
+  return someFunction({ prop: data });
+                      ~~~~~~~~~~~~~~
+}
+`,
+    }),
+
+    convertAnnotatedSourceToFailureCase({
+      messageId,
+      description: 'Object literal in variable declaration with methods',
+      annotatedSource: `
+const handler = { handle() {}, process() {} };
+                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`,
+    }),
+
+    convertAnnotatedSourceToFailureCase({
+      messageId,
+      description: 'Object literal as return value',
+      annotatedSource: `
+return { data: 'value' };
+       ~~~~~~~~~~~~~~~~~`,
+    }),
+  ],
+});

--- a/packages/eslint-plugin/src/lib/no-object-literals/no-object-literals.ts
+++ b/packages/eslint-plugin/src/lib/no-object-literals/no-object-literals.ts
@@ -1,0 +1,40 @@
+import { TSESLint, TSESTree } from '@typescript-eslint/utils';
+
+import { messageId } from './message-id.const';
+
+const rule: TSESLint.RuleModule<typeof messageId, never[]> = {
+  defaultOptions: [],
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow object literals except in constructors',
+    },
+    messages: {
+      [messageId]: 'Object literals are not allowed. Use a class instead.',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      ObjectExpression(node: TSESTree.ObjectExpression) {
+        const parent = node.parent;
+
+        // Allow object literals in constructor calls
+        if (
+          parent?.type === 'NewExpression' &&
+          parent.arguments.includes(node)
+        ) {
+          return;
+        }
+
+        // Report all other object literals
+        context.report({
+          node,
+          messageId,
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin/src/lib/no-object-literals/no-object-literals.ts
+++ b/packages/eslint-plugin/src/lib/no-object-literals/no-object-literals.ts
@@ -1,8 +1,14 @@
-import { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
 
 import { messageId } from './message-id.const';
+import { noObjectLiterals } from './no-object-literals.const';
 
-const rule: TSESLint.RuleModule<typeof messageId, never[]> = {
+function fileName(): string {
+  return __filename;
+}
+
+export default ESLintUtils.RuleCreator(fileName)({
+  name: noObjectLiterals,
   defaultOptions: [],
   meta: {
     type: 'suggestion',
@@ -14,7 +20,7 @@ const rule: TSESLint.RuleModule<typeof messageId, never[]> = {
     },
     schema: [],
   },
-  create(context) {
+  create: function create(context) {
     return {
       ObjectExpression(node: TSESTree.ObjectExpression) {
         const parent = node.parent;
@@ -35,6 +41,4 @@ const rule: TSESLint.RuleModule<typeof messageId, never[]> = {
       },
     };
   },
-};
-
-export default rule;
+});


### PR DESCRIPTION
# Issue Number: #5 

# Body

Adds the no-object-literals rule
also updates dependabot.yml so it will start updating dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new ESLint rule `no-object-literals` to the `@smarttools/eslint-plugin`
    - Discourages using object literals outside of constructor calls
    - Aims to improve code readability and performance

- **Documentation**
  - Updated README files with details about the new `no-object-literals` rule
  - Explained rationale behind avoiding object literals

- **Chores**
  - Updated Dependabot configuration from pnpm to npm ecosystem
<!-- end of auto-generated comment: release notes by coderabbit.ai -->